### PR TITLE
Ensure that direct upload works

### DIFF
--- a/lib/active_storage/service/bunny_service.rb
+++ b/lib/active_storage/service/bunny_service.rb
@@ -44,6 +44,14 @@ module ActiveStorage
       end
     end
 
+    def download_chunk(key, range)
+      instrument :download_chunk, key: key, range: range do
+        io = StringIO.new object_for(key).get_file(range: "bytes=#{range.begin}-#{range.exclude_end? ? range.end - 1 : range.end}")
+
+        io.set_encoding(Encoding::BINARY)
+      end
+    end
+
     def delete(key)
       instrument :delete, key: key do
         object_for(key).delete_file

--- a/lib/active_storage_bunny/version.rb
+++ b/lib/active_storage_bunny/version.rb
@@ -1,3 +1,3 @@
 module ActiveStorageBunny
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end

--- a/lib/active_storage_bunny/version.rb
+++ b/lib/active_storage_bunny/version.rb
@@ -1,3 +1,3 @@
 module ActiveStorageBunny
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.0.3'.freeze
 end


### PR DESCRIPTION
Ensuring that direct uploads work with Bunny

* Updated the `url_for_direct_upload` method to generate a URL based on the `region` and `storage_zone` attributes.
* Modified the `headers_for_direct_upload` method to include the `access_key` and set the `Content-Type` to 'application/octet-stream'.
* Added a `custom_metadata_headers` method that currently returns an empty hash.